### PR TITLE
Disambiguate app modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/*
+.liquid/*
 data/*
 *.swp
 cabal-helper*build/

--- a/app/PerfTestApp/Main.hs
+++ b/app/PerfTestApp/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE PackageImports #-}
 
 module Main where
 

--- a/app/PerfTestApp/Main.hs
+++ b/app/PerfTestApp/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports #-}
 
 module Main where
 
@@ -9,9 +10,9 @@ import qualified Data.Map      as Map
 import qualified Data.Set      as Set
 import           Hydra.Prelude
 
-import qualified Free          as Free
-import qualified FTL           as FTL
-import qualified Church        as Church
+import qualified PerfFree          as Free
+import qualified PerfFTL           as FTL
+import qualified PerfChurch        as Church
 import qualified Hydra.Domain  as D
 import qualified Hydra.Runtime as R
 import qualified Hydra.Framework.RLens as RLens

--- a/app/PerfTestApp/PerfChurch.hs
+++ b/app/PerfTestApp/PerfChurch.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Church where
+module PerfChurch where
 
 import           Control.Monad
 import qualified Data.Map      as Map
@@ -12,7 +12,7 @@ import           Hydra.Prelude
 import qualified Hydra.ChurchL  as L
 import qualified Hydra.Domain  as D
 import qualified Hydra.Runtime as R
-import           Types
+import           PerfTypes
 
 
 getRandomMeteor :: L.RandomL Meteor

--- a/app/PerfTestApp/PerfFTL.hs
+++ b/app/PerfTestApp/PerfFTL.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module FTL where
+module PerfFTL where
 
 import           Control.Monad
 import qualified Data.Map      as Map
@@ -12,7 +12,7 @@ import           Hydra.Prelude
 import qualified Hydra.Domain  as D
 import qualified Hydra.FTL     as FTL
 import qualified Hydra.Runtime as R
-import           Types
+import           PerfTypes
 
 import           Hydra.FTLI    ()
 

--- a/app/PerfTestApp/PerfFree.hs
+++ b/app/PerfTestApp/PerfFree.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Free where
+module PerfFree where
 
 import           Control.Monad
 import qualified Data.Map       as Map
@@ -12,7 +12,7 @@ import           Hydra.Prelude
 import qualified Hydra.Domain   as D
 import qualified Hydra.Language as L
 import qualified Hydra.Runtime  as R
-import           Types
+import           PerfTypes
 
 
 getRandomMeteor :: L.RandomL Meteor

--- a/app/PerfTestApp/PerfTypes.hs
+++ b/app/PerfTestApp/PerfTypes.hs
@@ -1,4 +1,4 @@
-module Types where
+module PerfTypes where
 
 import           Hydra.Prelude
 


### PR DESCRIPTION
I tried to explore app through ghci and realized that ghci breaks due meteor and perf apps have bunch of same modules. So I renamed perf modules.


```
$ stack ghci

* * * * * * * *
The main module to load is ambiguous. Candidates are: 
1. Package `Hydra' component Hydra:exe:astro-app with main-is file: /home/dan/demo/haskell/gsoc/Hydra/app/astro/Main.hs
2. Package `Hydra' component Hydra:exe:labyrinth with main-is file: /home/dan/demo/haskell/gsoc/Hydra/app/labyrinth/Main.hs
3. Package `Hydra' component Hydra:exe:meteor-counter-app with main-is file: /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/Main.hs
4. Package `Hydra' component Hydra:exe:perf-test-app with main-is file: /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/Main.hs
You can specify which one to pick by: 
 * Specifying targets to stack ghci e.g. stack ghci Hydra:exe:astro-app
 * Specifying what the main is e.g. stack ghci --main-is Hydra:exe:astro-app
 * Choosing from the candidate above [1..4]
* * * * * * * *

Specify main module to use (press enter to load none): 3
Loading main module from candidate 3, --main-is /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/Main.hs

The following GHC options are incompatible with GHCi and have not been passed to it: -threaded -O2
Configuring GHCi with the following packages: Hydra

* * * * * * * *

Error: Multiple files use the same module name:
       * Church found at the following paths
         * /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/Church.hs (Hydra:exe:meteor-counter-app)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/Church.hs (Hydra:exe:perf-test-app)
       * FTL found at the following paths
         * /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/FTL.hs (Hydra:exe:meteor-counter-app)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/FTL.hs (Hydra:exe:perf-test-app)
       * Free found at the following paths
         * /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/Free.hs (Hydra:exe:meteor-counter-app)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/Free.hs (Hydra:exe:perf-test-app)
       * Types found at the following paths
         * /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/Types.hs (Hydra:exe:meteor-counter-app)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/Types.hs (Hydra:exe:perf-test-app)
* * * * * * * *

Not attempting to start ghci due to these duplicate modules.
Use --no-load to try to start it anyway, without loading any modules (but these are still likely to cause errors)


```