### PR TITLE
remove-unsed-imports-in-core remove unused imports in core

### DIFF
--- a/src/Hydra/Core/ControlFlow/ChurchI.hs
+++ b/src/Hydra/Core/ControlFlow/ChurchI.hs
@@ -2,7 +2,6 @@ module Hydra.Core.ControlFlow.ChurchI where
 
 import qualified Hydra.Core.ControlFlow.ChurchL     as CL
 import qualified Hydra.Core.ControlFlow.Interpreter as I
-import qualified Hydra.Core.ControlFlow.Language    as L
 import           Hydra.Prelude
 
 import qualified Hydra.Core.Runtime                 as R

--- a/src/Hydra/Core/Domain/Cli.hs
+++ b/src/Hydra/Core/Domain/Cli.hs
@@ -1,7 +1,7 @@
 module Hydra.Core.Domain.Cli where
 
 import           Hydra.Prelude
-import           Hydra.Core.Domain.State (StateVar, SignalVar)
+import           Hydra.Core.Domain.State (SignalVar)
 
 
 data CliToken = CliToken

--- a/src/Hydra/Core/Domain/DB.hs
+++ b/src/Hydra/Core/Domain/DB.hs
@@ -7,16 +7,7 @@ module Hydra.Core.Domain.DB where
 
 import           Hydra.Prelude
 
-import qualified Data.Aeson           as A
-import qualified Data.ByteString.Lazy as LBS
 import           Data.Time.Clock                    (NominalDiffTime)
-import qualified Data.Pool                       as DP
-import qualified Database.Beam                   as B
-import qualified Database.Beam.Backend.SQL       as B
-import qualified Database.Beam.Sqlite            as BS
-import qualified Database.Beam.Sqlite.Connection as SQLite
-import           Database.Beam.Sqlite            (Sqlite)
-import qualified Database.SQLite.Simple          as SQLite
 
 
 data DBErrorType

--- a/src/Hydra/Core/Domain/SQLDB.hs
+++ b/src/Hydra/Core/Domain/SQLDB.hs
@@ -12,16 +12,11 @@ module Hydra.Core.Domain.SQLDB where
 
 import           Hydra.Prelude
 
-import qualified Data.Aeson           as A
-import qualified Data.ByteString.Lazy as LBS
-import           System.FilePath ((</>))
-import           Data.Time.Clock                    (NominalDiffTime)
 import qualified Data.Pool                       as DP
 import qualified Database.Beam                   as B
 import qualified Database.Beam.Backend.SQL       as B
 import qualified Database.Beam.Sqlite            as BS
 import qualified Database.Beam.Sqlite.Connection as SQLite
-import           Database.Beam.Sqlite            (Sqlite)
 import qualified Database.SQLite.Simple          as SQLite
 
 import           Hydra.Core.Domain.DB

--- a/src/Hydra/Core/KVDB/Interpreter.hs
+++ b/src/Hydra/Core/KVDB/Interpreter.hs
@@ -3,10 +3,7 @@ module Hydra.Core.KVDB.Interpreter where
 import           Hydra.Prelude
 
 import qualified Hydra.Core.Language as L
-import qualified Hydra.Core.RLens    as RLens
-import qualified Hydra.Core.Runtime  as R
 import qualified Hydra.Core.KVDBRuntime as R
-import qualified Hydra.Core.Domain   as D
 
 import qualified Database.RocksDB as Rocks
 import qualified Database.Redis as Redis

--- a/src/Hydra/Core/KVDB/Redis/Language.hs
+++ b/src/Hydra/Core/KVDB/Redis/Language.hs
@@ -17,9 +17,5 @@
 
 module Hydra.Core.KVDB.Redis.Language where
 
-import           Hydra.Prelude
 
-import qualified Hydra.Core.Domain.DB   as D
-import qualified Hydra.Core.Domain.KVDB as D
 
-import qualified Database.Redis as Redis

--- a/src/Hydra/Core/KVDBRuntime.hs
+++ b/src/Hydra/Core/KVDBRuntime.hs
@@ -5,7 +5,6 @@ import           Hydra.Prelude
 import qualified Data.Map                        as Map
 
 import qualified Hydra.Core.Domain               as D
-import qualified Hydra.Core.Language             as L
 
 import qualified Database.RocksDB as Rocks
 import qualified Database.Redis as Redis

--- a/src/Hydra/Core/Lang/ChurchI.hs
+++ b/src/Hydra/Core/Lang/ChurchI.hs
@@ -4,8 +4,6 @@ import           Hydra.Prelude
 
 import           Hydra.Core.ControlFlow.ChurchI         (runControlFlowL)
 import qualified Hydra.Core.Lang.ChurchL                as CL
-import qualified Hydra.Core.Lang.Interpreter            as I
-import qualified Hydra.Core.Lang.Language               as L
 import           Hydra.Core.Logger.Impl.HsLoggerChurchI (runLoggerL)
 import           Hydra.Core.Random.ChurchI              (runRandomL)
 import qualified Hydra.Core.RLens                       as RLens

--- a/src/Hydra/Core/Lang/ChurchL.hs
+++ b/src/Hydra/Core/Lang/ChurchL.hs
@@ -8,16 +8,12 @@ import           Hydra.Prelude
 
 import qualified Hydra.Core.ControlFlow.ChurchL  as CL
 import qualified Hydra.Core.ControlFlow.Class    as C
-import qualified Hydra.Core.ControlFlow.Language as L
 import qualified Hydra.Core.Logger.ChurchL       as CL
 import qualified Hydra.Core.Logger.Class         as C
-import qualified Hydra.Core.Logger.Language      as L
 import qualified Hydra.Core.Random.ChurchL       as CL
 import qualified Hydra.Core.Random.Class         as C
-import qualified Hydra.Core.Random.Language      as L
 import qualified Hydra.Core.State.ChurchL        as CL
 import qualified Hydra.Core.State.Class          as C
-import qualified Hydra.Core.State.Language       as L
 import qualified Hydra.Core.Lang.Class           as C
 
 import           Language.Haskell.TH.MakeFunctor (makeFunctorInstance)

--- a/src/Hydra/Core/Lang/Class.hs
+++ b/src/Hydra/Core/Lang/Class.hs
@@ -7,12 +7,10 @@ module Hydra.Core.Lang.Class where
 import           Hydra.Prelude
 
 import qualified Hydra.Core.ControlFlow.Class    as C
-import qualified Hydra.Core.Domain               as D
 import qualified Hydra.Core.Logger.Class         as C
 import qualified Hydra.Core.Random.Class         as C
 import qualified Hydra.Core.State.Class          as C
 
-import           Language.Haskell.TH.MakeFunctor (makeFunctorInstance)
 
 -- TODO: this is awful
 class (C.Logger l, C.Random r, C.ControlFlow cf, C.State' s, Monad m)

--- a/src/Hydra/Core/Lang/FTL.hs
+++ b/src/Hydra/Core/Lang/FTL.hs
@@ -7,7 +7,6 @@ module Hydra.Core.Lang.FTL where
 
 import           Hydra.Prelude
 
-import           Hydra.Core.ControlFlow.FTL as L
 import           Hydra.Core.Logger.FTL      as L
 import           Hydra.Core.Random.FTL      as L
 import qualified Hydra.Core.State.Class     as L

--- a/src/Hydra/Core/Lang/FTLI.hs
+++ b/src/Hydra/Core/Lang/FTLI.hs
@@ -8,7 +8,6 @@ import           Hydra.Core.Random.FTLI       ()
 import qualified Hydra.Core.RLens             as RLens
 import qualified Hydra.Core.Runtime           as R
 import qualified Hydra.Core.State.Interpreter as Impl
-import qualified Hydra.Core.State.Language    as L
 
 instance L.LangL (ReaderT R.CoreRuntime IO) where
 -- instance MonadIO m => L.LangL (ReaderT R.CoreRuntime m) where

--- a/src/Hydra/Core/Lang/Interpreter.hs
+++ b/src/Hydra/Core/Lang/Interpreter.hs
@@ -13,13 +13,11 @@ import           Hydra.Core.Logger.Impl.HsLoggerInterpreter (runLoggerL)
 import           Hydra.Core.Random.Interpreter              (runRandomL)
 import qualified Hydra.Core.RLens                           as RLens
 import qualified Hydra.Core.Runtime                         as R
-import qualified Hydra.Core.KVDBRuntime                     as R
 import qualified Hydra.Core.Domain                          as D
 import           Hydra.Core.State.Interpreter               (runStateL)
 import           Hydra.Core.KVDB.Interpreter                (runAsRocksDBL, runAsRedisL)
 import           Hydra.Core.SqlDB.Interpreter               (runSqlDBL)
 import qualified Hydra.Core.SqlDBRuntime                    as R
-import qualified Database.RocksDB                           as Rocks
 import qualified Servant.Client                             as S
 
 evalRocksKVDB'

--- a/src/Hydra/Core/Lang/Language.hs
+++ b/src/Hydra/Core/Lang/Language.hs
@@ -19,12 +19,6 @@ import qualified Hydra.Core.SqlDB.Language       as L
 import qualified Hydra.Core.Lang.Class           as C
 import qualified Hydra.Core.Domain               as D
 
-import           Language.Haskell.TH.MakeFunctor (makeFunctorInstance)
-import           Database.Beam.Backend.SQL (BeamSqlBackend)
-import           Database.Beam (FromBackendRow, SqlSelect)
-import           Database.Beam.Sqlite (Sqlite)
-import qualified Database.Beam as B
-import qualified Database.Beam.Backend.SQL as B
 import           Servant.Client (ClientM, ClientError, BaseUrl)
 
 -- | Core effects container language.

--- a/src/Hydra/Core/Logger/Impl/HsLogger.hs
+++ b/src/Hydra/Core/Logger/Impl/HsLogger.hs
@@ -2,7 +2,6 @@ module Hydra.Core.Logger.Impl.HsLogger where
 
 import           Hydra.Prelude
 
-import qualified Data.Text                 as TXT (unpack)
 import           System.IO                 (Handle, stdout)
 import           System.Log.Formatter
 import           System.Log.Handler        (close, setFormatter)
@@ -11,7 +10,6 @@ import           System.Log.Logger
 
 import qualified Hydra.Core.Domain         as D
 import qualified Hydra.Core.Language       as L
-
 -- | Opaque type covering all information needed to teardown the logger.
 data HsLoggerHandle = HsLoggerHandle
   { handlers :: [GenericHandler Handle]

--- a/src/Hydra/Core/Logger/Impl/HsLoggerChurchI.hs
+++ b/src/Hydra/Core/Logger/Impl/HsLoggerChurchI.hs
@@ -2,20 +2,7 @@ module Hydra.Core.Logger.Impl.HsLoggerChurchI where
 
 import           Hydra.Prelude
 
-import qualified Data.Text                 as TXT (unpack)
-import           System.IO                 (Handle, stdout)
-import           System.Log.Formatter
-import           System.Log.Handler        (close, setFormatter)
-import           System.Log.Handler.Simple (GenericHandler, fileHandler, streamHandler)
-import           System.Log.Logger
-
-import qualified Hydra.Core.Domain         as D
-import qualified Hydra.Core.ChurchL        as CL
-import qualified Hydra.Core.Language       as L
-import           Hydra.Core.Logger.Impl.HsLogger
 import qualified Hydra.Core.Logger.Impl.HsLoggerInterpreter as I
 
-
-runLoggerL :: Maybe HsLoggerHandle -> CL.LoggerL () -> IO ()
 runLoggerL (Just h) l = foldF (I.interpretLoggerF h) l
 runLoggerL Nothing  _ = pure ()

--- a/src/Hydra/Core/Logger/Impl/HsLoggerInterpreter.hs
+++ b/src/Hydra/Core/Logger/Impl/HsLoggerInterpreter.hs
@@ -3,16 +3,11 @@ module Hydra.Core.Logger.Impl.HsLoggerInterpreter where
 import           Hydra.Prelude
 
 import qualified Data.Text                 as TXT (unpack)
-import           System.IO                 (Handle, stdout)
-import           System.Log.Formatter
-import           System.Log.Handler        (close, setFormatter)
-import           System.Log.Handler.Simple (GenericHandler, fileHandler, streamHandler)
 import           System.Log.Logger
 
 import qualified Hydra.Core.Domain         as D
 import qualified Hydra.Core.Language       as L
 import           Hydra.Core.Logger.Impl.HsLogger
-
 
 -- | Interpret LoggerL language.
 interpretLoggerF :: HsLoggerHandle -> L.LoggerF a -> IO a

--- a/src/Hydra/Core/Process/ChurchI.hs
+++ b/src/Hydra/Core/Process/ChurchI.hs
@@ -4,13 +4,10 @@ module Hydra.Core.Process.ChurchI where
 
 import           Hydra.Prelude
 
-import qualified Data.Map                  as M
-
 import qualified Hydra.Core.ChurchL        as CL
 import qualified Hydra.Core.Domain.Process as D
 import qualified Hydra.Core.Language       as L
 import           Hydra.Core.Process.Impl
-import qualified Hydra.Core.RLens          as RLens
 import qualified Hydra.Core.Runtime        as R
 
 interpretProcessF :: LangRunner m' -> R.ProcessRuntime -> L.ProcessF m' a -> IO a

--- a/src/Hydra/Core/Process/ChurchL.hs
+++ b/src/Hydra/Core/Process/ChurchL.hs
@@ -7,7 +7,6 @@ import           Hydra.Prelude
 
 import qualified Hydra.Core.Domain           as D
 import qualified Hydra.Core.Process.Language as L
-import Hydra.Core.Process.Class
 
 type ProcessL m = F (L.ProcessF m)
 

--- a/src/Hydra/Core/Process/FTLI.hs
+++ b/src/Hydra/Core/Process/FTLI.hs
@@ -3,16 +3,7 @@
 
 module Hydra.Core.Process.FTLI where
 
-import           Hydra.Prelude
 
-import qualified Hydra.Core.Domain.Process      as D
-import qualified Hydra.Core.FTL                 as L
-import qualified Hydra.Core.Process.Interpreter as Impl
-import qualified Hydra.Core.RLens               as RLens
-import qualified Hydra.Core.Runtime             as R
-
-
--- instance L.ProcessL (ReaderT R.CoreRuntime IO) where
 --   forkProcess action = do
 --     coreRt <- ask
 --     let processRt = coreRt ^. RLens.processRuntime

--- a/src/Hydra/Core/Process/Impl.hs
+++ b/src/Hydra/Core/Process/Impl.hs
@@ -7,7 +7,6 @@ import           Hydra.Prelude
 import qualified Data.Map                  as M
 
 import qualified Hydra.Core.Domain.Process as D
-import qualified Hydra.Core.Language       as L
 import qualified Hydra.Core.RLens          as RLens
 import qualified Hydra.Core.Runtime        as R
 

--- a/src/Hydra/Core/Process/Interpreter.hs
+++ b/src/Hydra/Core/Process/Interpreter.hs
@@ -2,12 +2,9 @@ module Hydra.Core.Process.Interpreter where
 
 import           Hydra.Prelude
 
-import qualified Data.Map                  as M
-
 import qualified Hydra.Core.Domain.Process as D
 import qualified Hydra.Core.Language       as L
 import           Hydra.Core.Process.Impl
-import qualified Hydra.Core.RLens          as RLens
 import qualified Hydra.Core.Runtime        as R
 
 interpretProcessF :: LangRunner m' -> R.ProcessRuntime -> L.ProcessF m' a -> IO a

--- a/src/Hydra/Core/Process/Language.hs
+++ b/src/Hydra/Core/Process/Language.hs
@@ -7,7 +7,6 @@ import           Hydra.Prelude
 
 import qualified Hydra.Core.Domain               as D
 
-import           Language.Haskell.TH.MakeFunctor (makeFunctorInstance)
 
 -- | Language for Process.
 data ProcessF m' next where

--- a/src/Hydra/Core/Random/ChurchI.hs
+++ b/src/Hydra/Core/Random/ChurchI.hs
@@ -2,13 +2,10 @@ module Hydra.Core.Random.ChurchI where
 
 import           Hydra.Prelude
 
-import           System.Entropy
-import           System.Random       hiding (next)
 
 import qualified Hydra.Core.ChurchL as CL
 import qualified Hydra.Core.Random.Interpreter as I
 import qualified Hydra.Core.Language as L
 
--- | Interpret RandomL language.
 runRandomL :: CL.RandomL a -> IO a
 runRandomL = foldF I.interpretRandomF

--- a/src/Hydra/Core/Random/FTL.hs
+++ b/src/Hydra/Core/Random/FTL.hs
@@ -5,7 +5,6 @@ module Hydra.Core.Random.FTL where
 
 import           Hydra.Prelude
 
-import qualified Hydra.Core.Domain as D
 
 
 class Monad m => RandomL m where

--- a/src/Hydra/Core/Random/FTLI.hs
+++ b/src/Hydra/Core/Random/FTLI.hs
@@ -1,14 +1,10 @@
 module Hydra.Core.Random.FTLI where
 
 import           Hydra.Prelude
-import           System.Entropy
 import           System.Random                hiding (next)
 
 import qualified Hydra.Core.FTL               as L
-import qualified Hydra.Core.RLens             as RLens
 import qualified Hydra.Core.Runtime           as R
-import qualified Hydra.Core.State.Interpreter as Impl
-import qualified Hydra.Core.State.Language    as L
 
 instance MonadIO m => L.RandomL (ReaderT R.CoreRuntime m) where
   getRandomInt range = liftIO $ randomRIO range

--- a/src/Hydra/Core/Random/Interpreter.hs
+++ b/src/Hydra/Core/Random/Interpreter.hs
@@ -2,7 +2,6 @@ module Hydra.Core.Random.Interpreter where
 
 import           Hydra.Prelude
 
-import           System.Entropy
 import           System.Random       hiding (next)
 
 import qualified Hydra.Core.Language as L

--- a/src/Hydra/Core/Runtime.hs
+++ b/src/Hydra/Core/Runtime.hs
@@ -10,10 +10,6 @@ import qualified Hydra.Core.Logger.Impl.HsLogger as Impl
 import qualified Hydra.Core.Logger.Impl.HsLoggerInterpreter as I
 
 import qualified Hydra.Core.KVDBRuntime as R
-import qualified Hydra.Core.SqlDBRuntime as R
-import qualified Database.RocksDB as Rocks
-import qualified Database.Redis as Redis
-import qualified Database.SQLite.Simple as SQLite
 
 import           Network.HTTP.Client     (Manager, newManager)
 import           Network.HTTP.Client.TLS (tlsManagerSettings)

--- a/src/Hydra/Core/SqlDB/Interpreter.hs
+++ b/src/Hydra/Core/SqlDB/Interpreter.hs
@@ -4,8 +4,6 @@ import Hydra.Prelude
 
 import qualified Hydra.Core.SqlDB.Language as L
 import qualified Hydra.Core.Domain as D
-import qualified Database.Beam as B
-import qualified Database.Beam.Backend.SQL as B
 
 
 interpretSqlDBMethod

--- a/src/Hydra/Core/SqlDB/Language.hs
+++ b/src/Hydra/Core/SqlDB/Language.hs
@@ -7,8 +7,6 @@ module Hydra.Core.SqlDB.Language where
 
 import           Hydra.Prelude
 import qualified Database.Beam as B
-import qualified Database.Beam.Backend.SQL as B
-import qualified Database.Beam.Query as B
 import qualified Hydra.Core.Domain as D
 
 

--- a/src/Hydra/Core/SqlDBRuntime.hs
+++ b/src/Hydra/Core/SqlDBRuntime.hs
@@ -3,17 +3,9 @@ module Hydra.Core.SqlDBRuntime where
 
 import           Hydra.Prelude
 
-import qualified Data.Map                        as Map
-
 import qualified Hydra.Core.Domain               as D
-import qualified Hydra.Core.Language             as L
 
 import qualified Data.Pool                       as DP
-import qualified Database.Beam                   as B
-import qualified Database.Beam.Backend.SQL       as B
-import qualified Database.Beam.Sqlite            as BS
-import qualified Database.Beam.Sqlite.Connection as SQLite
-import           Database.Beam.Sqlite            (Sqlite)
 import qualified Database.SQLite.Simple          as SQLite
 
 bemToNative :: D.SqlConn beM -> D.NativeSqlConn

--- a/src/Hydra/Core/State/ChurchI.hs
+++ b/src/Hydra/Core/State/ChurchI.hs
@@ -4,9 +4,6 @@ module Hydra.Core.State.ChurchI where
 
 import           Hydra.Prelude
 
-import qualified Data.Map                               as Map
-import           Unsafe.Coerce                          (unsafeCoerce)
-
 import qualified Hydra.Core.Domain                      as D
 import qualified Hydra.Core.RLens                       as RLens
 import qualified Hydra.Core.Runtime                     as R

--- a/src/Hydra/Core/State/Interpreter.hs
+++ b/src/Hydra/Core/State/Interpreter.hs
@@ -4,8 +4,6 @@ module Hydra.Core.State.Interpreter where
 
 import           Hydra.Prelude
 
-import qualified Data.Map                         as Map
-import           Unsafe.Coerce                    (unsafeCoerce)
 
 import qualified Hydra.Core.Domain                as D
 import qualified Hydra.Core.Language              as L

--- a/src/Hydra/Framework/App/ChurchI.hs
+++ b/src/Hydra/Framework/App/ChurchI.hs
@@ -4,8 +4,6 @@ import           Hydra.Prelude
 
 import qualified Hydra.Core.ChurchI       as CI
 import qualified Hydra.Core.ChurchL       as CL
-import qualified Hydra.Core.Domain        as D
-import qualified Hydra.Core.Language      as L
 import qualified Hydra.Core.RLens         as RLens
 import qualified Hydra.Core.Runtime       as R
 

--- a/src/Hydra/Framework/App/Interpreter.hs
+++ b/src/Hydra/Framework/App/Interpreter.hs
@@ -3,7 +3,6 @@ module Hydra.Framework.App.Interpreter where
 import           Hydra.Prelude
 
 import qualified Data.Map as Map
-import qualified Data.Text as T
 
 import qualified Hydra.Core.Domain        as D
 import qualified Hydra.Core.Interpreters  as Impl
@@ -16,12 +15,7 @@ import qualified Hydra.Framework.Language as L
 import qualified Hydra.Framework.RLens    as RLens
 import qualified Hydra.Framework.Runtime  as R
 
-import qualified Database.RocksDB         as Rocks
-import qualified Database.Redis           as Redis
-import qualified Database.SQLite.Simple   as SQLite
-import           Database.Beam.Sqlite     (Sqlite)
 import qualified System.Console.Haskeline         as HS
-import qualified System.Console.Haskeline.History as HS
 
 langRunner :: R.CoreRuntime -> Impl.LangRunner L.LangL
 langRunner coreRt = Impl.LangRunner (Impl.runLangL coreRt)

--- a/src/Hydra/Framework/App/Language.hs
+++ b/src/Hydra/Framework/App/Language.hs
@@ -10,10 +10,6 @@ import qualified Hydra.Core.Class                as C
 import qualified Hydra.Core.Domain               as D
 import qualified Hydra.Core.Language             as L
 
-import           Language.Haskell.TH.MakeFunctor (makeFunctorInstance)
-import           Database.Beam.Sqlite (Sqlite)
-import qualified Database.Beam as B
-import qualified Database.Beam.Backend.SQL as B
 import qualified System.Console.Haskeline as HS
 
 -- | App language.


### PR DESCRIPTION
Hydra project is positioned as blue print, but there are so many warnings.

I started to figuring out where Sqlite is mentioned and my grep results get polluted with unused Beam imports. 

I wasn't able to find what is the correct way to handle following reexports. GHC complains anyway

```
module Hydra.Core.FTLI
  ( module X
  ) where

import           Hydra.Core.Lang.FTLI        as X
import           Hydra.Core.Logger.FTLI      as X
import           Hydra.Core.Process.FTLI     as X
import           Hydra.Core.Random.FTLI      as X

```
 