### PR TITLE
disambiguate-perf2 disambiguate-perf2

### DIFF
--- a/app/MeteorCounter/src/Main.hs
+++ b/app/MeteorCounter/src/Main.hs
@@ -45,7 +45,7 @@ main = do
   putStrLn @String $ "Method: " <> show (method cfg)
 
   let mbLoggerCfg = if useLog cfg then Just loggerCfg else Nothing
-  
+
   R.withAppRuntime mbLoggerCfg $ \appRt -> do
     when (method cfg == FT)
       $ FTL.scenario (appRt ^. RLens.coreRuntime)

--- a/app/PerfTestApp2/src/Main.hs
+++ b/app/PerfTestApp2/src/Main.hs
@@ -9,9 +9,9 @@ import qualified Data.Map      as Map
 import qualified Data.Set      as Set
 import           Hydra.Prelude
 
-import qualified Free          as Free
-import qualified FTL           as FTL
-import qualified Church        as Church
+import qualified Perf2Free     as Free
+import qualified Perf2FTL      as FTL
+import qualified Perf2Church   as Church
 import qualified IO            as IO
 import qualified Hydra.Domain  as D
 import qualified Hydra.Runtime as R

--- a/app/PerfTestApp2/src/Perf2Church.hs
+++ b/app/PerfTestApp2/src/Perf2Church.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Church where
+module Perf2Church where
 
 import           Control.Monad
 import qualified Data.Map      as Map

--- a/app/PerfTestApp2/src/Perf2FTL.hs
+++ b/app/PerfTestApp2/src/Perf2FTL.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module FTL where
+module Perf2FTL where
 
 import           Control.Monad
 import qualified Data.Map      as Map

--- a/app/PerfTestApp2/src/Perf2Free.hs
+++ b/app/PerfTestApp2/src/Perf2Free.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Free where
+module Perf2Free where
 
 import           Control.Monad
 import qualified Data.Map       as Map


### PR DESCRIPTION
Fix module name collision in ghci.

This helps but doesn't solve ghci problem completely.
Since last stack reorganization ghci complains on duplicated Main modules too.
I cannot rename them. 
I tried to find a workaround with --main-is astro:exe:astro,
but ghci needs -threaded option.
I've not found how to pass it through stack ghci.
GHCi helps a lot during getting familiar with codebase.

```
stack ghci --main-is MeteorCounter:exe:MeteorCounter
Using main module: 1. Package `MeteorCounter' component MeteorCounter:exe:MeteorCounter with main-is file: /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/src/Main.hs
The following GHC options are incompatible with GHCi and have not been passed to it: -threaded
Configuring GHCi with the following packages: Hydra, MeteorCounter, PerfTestApp, PerfTestApp2, astro, labyrinth

* * * * * * * *

Error: Multiple files use the same module name:
       * Main found at the following paths
         * /home/dan/demo/haskell/gsoc/Hydra/app/MeteorCounter/src/Main.hs (MeteorCounter:lib)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp/src/Main.hs (PerfTestApp:lib)
         * /home/dan/demo/haskell/gsoc/Hydra/app/PerfTestApp2/src/Main.hs (PerfTestApp2:lib)
         * /home/dan/demo/haskell/gsoc/Hydra/app/astro/src/Main.hs (astro:lib)
         * /home/dan/demo/haskell/gsoc/Hydra/app/labyrinth/src/Main.hs (labyrinth:lib)
* * * * * * * *

Not attempting to start ghci due to these duplicate modules.
Use --no-load to try to start it anyway, without loading any modules (but these are still likely to cause errors)

```

