### PR TITLE
orphan: move instance church random to same module with base type

### DIFF
--- a/lib/Hydra/src/Hydra/Core/Random/ChurchL.hs
+++ b/lib/Hydra/src/Hydra/Core/Random/ChurchL.hs
@@ -1,15 +1,5 @@
-{-# LANGUAGE GADTs           #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Hydra.Core.Random.ChurchL where
 
-import           Hydra.Prelude
-
-import qualified Hydra.Core.Random.Class    as L
 import qualified Hydra.Core.Random.Language as L
 
-
-type RandomL = F L.RandomF
-
-instance L.Random RandomL where
-  getRandomInt range = liftFC $ L.GetRandomInt range id
+type RandomL = L.ChurchRandomL

--- a/lib/Hydra/src/Hydra/Core/Random/Language.hs
+++ b/lib/Hydra/src/Hydra/Core/Random/Language.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GADTs           #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Hydra.Core.Random.Language where
 
 import           Hydra.Prelude
@@ -21,3 +18,9 @@ type RandomL = Free RandomF
 
 instance Random RandomL where
   getRandomInt range = liftF $ GetRandomInt range id
+
+
+type ChurchRandomL = F RandomF
+
+instance Random ChurchRandomL where
+  getRandomInt range = liftFC $ GetRandomInt range id


### PR DESCRIPTION
An attempt to avoid orphan instance warning for Random.

I see that the app tries to represent multiple ways to solve problem - Free monad or Church monad.
In the real app such situation would not happen.

From one side both solution must be independent and data RandomF must copy-pasted for 
every case or both Random instances must reside in the same module.
 
I thought about wrapping  RandomF with a new type.

```
newtype ChurchRandomF next = ChurchRandomF (RandomF next)
type RandomL = F ChurchRandomF
```

definition of RandomF is reused but I am not sure about the rest of dependent code base.  

Besides orphan warning, trunk version is also asymmetric.
Why RandomF Free instance is defined in together with type definition but F is not?
I would expect to see 2 orphan warnings.

